### PR TITLE
Metrics Tweak so it works on DietPi 64 and Pi OS bullseye

### DIFF
--- a/grafana/dashboard_by_oijkn.json
+++ b/grafana/dashboard_by_oijkn.json
@@ -162,7 +162,7 @@
       "pluginVersion": "8.2.2",
       "targets": [
         {
-          "expr": "count(container_tasks_state{image!=""} and container_tasks_state{state=~"running"})",
+          "expr": "count(rate(container_tasks_state{image!="", state=~"running"}[$__range]))",
           "format": "time_series",
           "hide": false,
           "interval": "",

--- a/grafana/dashboard_by_oijkn.json
+++ b/grafana/dashboard_by_oijkn.json
@@ -162,7 +162,7 @@
       "pluginVersion": "8.2.2",
       "targets": [
         {
-          "expr": "count(rate(container_last_seen{id=~\"/docker/.*\"}[5m]))",
+          "expr": "count(container_tasks_state{image!=""} and container_tasks_state{state=~"running"})",
           "format": "time_series",
           "hide": false,
           "interval": "",


### PR DESCRIPTION
I was getting N/A for the Containers count.  I tweaking the metrics until it starting work.  I found I needed the same tweak on the new PI OS that is running Bullseye.  So I am submitting the tweak for your review.