### PR TITLE
Make dashboard independent to data source uid

### DIFF
--- a/grafana/dashboard_by_oijkn.json
+++ b/grafana/dashboard_by_oijkn.json
@@ -1,4 +1,53 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.3.3"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table-old",
+      "name": "Table (old)",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -23,15 +72,15 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 10566,
   "graphTooltip": 1,
-  "id": 2,
-  "iteration": 1640730899939,
+  "id": null,
+  "iteration": 1642345822861,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Time during which Pi is in operation",
       "fieldConfig": {
@@ -85,7 +134,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.4.0-46435pre",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "expr": "time() - node_boot_time_seconds",
@@ -157,12 +206,12 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.4.0-46435pre",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "t4f0shgRk"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
           "expr": "count(count by (name) (rate(container_tasks_state{image!=\"\", state=~\"running\"}[$__range])))",
@@ -181,7 +230,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Busy state of all CPU cores together",
       "fieldConfig": {
@@ -244,7 +293,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.4.0-46435pre",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "exemplar": true,
@@ -263,7 +312,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Non available RAM memory",
       "fieldConfig": {
@@ -318,7 +367,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.4.0-46435pre",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "exemplar": true,
@@ -349,7 +398,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Used Swap",
       "fieldConfig": {
@@ -412,7 +461,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.4.0-46435pre",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "exemplar": true,
@@ -430,7 +479,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Busy state of all CPU cores together (5 min average)",
       "fieldConfig": {
@@ -493,7 +542,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.4.0-46435pre",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "exemplar": true,
@@ -513,7 +562,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total used disk space",
       "fieldConfig": {
@@ -578,7 +627,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.4.0-46435pre",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "expr": "min((node_filesystem_size_bytes{fstype=~\"ext4\"} - node_filesystem_free_bytes{fstype=~\"ext4\"} )/ node_filesystem_size_bytes{fstype=~\"ext4\"})",
@@ -597,7 +646,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Hardware temperature",
       "fieldConfig": {
@@ -662,7 +711,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.4.0-46435pre",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "exemplar": true,
@@ -682,7 +731,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -840,7 +889,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -951,7 +1000,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1053,7 +1102,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1154,7 +1203,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1244,7 +1293,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1334,7 +1383,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Disk space used",
       "fieldConfig": {
@@ -1433,7 +1482,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1548,7 +1597,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The number (after merges) of I/O requests completed per second for the device",
       "fieldConfig": {
@@ -1969,7 +2018,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2083,7 +2132,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2175,7 +2224,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2274,7 +2323,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2375,7 +2424,7 @@
       "columns": [],
       "datasource": {
         "type": "prometheus",
-        "uid": "t4f0shgRk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fontSize": "100%",
       "gridPos": {
@@ -2577,6 +2626,6 @@
   "timezone": "browser",
   "title": "Docker and OS Metrics for Raspberry Pi",
   "uid": "Ss3q6hSZk",
-  "version": 36,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
I just started using grafana and had problems getting the dashboard run in my grafana container. I found, that the problem was the data source uid wich was different in my grafana container. So I had to change the uid manually in the dashboard json before importing it.

I reexported the dashboard with "Sharing -> Export" with the "Export for sharing externally" option set so the specific data source can be selected while importing the dashboard.