### PR TITLE
fix(docker-compose): typo in prometheus command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--storage.tsdb.retention.time=1y'
       # /!\ Uncomment the following line to set a size limit for the Prometheus database /!\
-#      - '--sotrage.tsdb.retention.size=10GB'
+#      - '--storage.tsdb.retention.size=10GB'
     networks:
       - internal
     expose:


### PR DESCRIPTION
Changed "sotrage" to "storage" in the prometheus section of the docker-compose file